### PR TITLE
Make github/discourse links easier to click

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -108,6 +108,8 @@ p,
 
 .fancypill a {
   color: rgb(249, 245, 236);
+  display: inine-block;
+  width: 100%;
 }
 
 .fancypill li:first-child {


### PR DESCRIPTION
This fixes the problem where the outer blue `<li>` appears to be a
clickable link, but in reality the anchor is only on the text.

This makes the anchor fill out the entire `<li>`, so you can click
anywhere to visit the link.