### PR TITLE
fix footer links and use names instead of domains

### DIFF
--- a/index.html
+++ b/index.html
@@ -107,14 +107,14 @@ wicg init "The Awesome API"</pre>
       <p>
         <small>
             Icons: Document by
-            <a href="http://www.icons8.com">
+            <a href="https://icons8.com">
               Icons8</a>, Link made by
-            <a href="http://www.simpleicon.com">
+            <a href="http://simpleicon.com">
               SimpleIcon</a>, from
-            <a href="http://www.flaticon.com">
-              www.flaticon.com</a>. Header font is `nexa`, from
-            <a href="www.fontfabric.com">
-              www.fontfabric.com</a>.
+            <a href="https://www.flaticon.com">
+              Flaticon</a>. Header font is "Nexa", from
+            <a href="https://www.fontfabric.com">
+              Fontfabric</a>.
           </small>
       </p>
     </section>


### PR DESCRIPTION
1. added a scheme for `www.fontfabric.com`, fixing that link
1. replaced URLs with their redirect target
1. in the anchor text, consistently use the name of the target instead its domain