### PR TITLE
Update generator.js: add discourse-archive to skip list

### DIFF
--- a/generator.js
+++ b/generator.js
@@ -42,6 +42,7 @@ const ignore_set = new Set([
   "starter-kit",
   "repo_info_generator",
   "discourse-wicg-theme",
+  "discourse-archive",
   "proposals",
   "wicg.github.io",
 ]);


### PR DESCRIPTION
 "discourse-archive" is showing up as an incubation 